### PR TITLE
fix: 8 bug fixes and typos - auth, roles, nav, and UX (#59-#66)

### DIFF
--- a/src/actions/__tests__/register-validation.test.ts
+++ b/src/actions/__tests__/register-validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock next-auth to avoid pnpm module resolution issues
+vi.mock("next-auth", () => ({
+  AuthError: class extends Error {
+    type: string;
+    constructor(message: string) {
+      super(message);
+      this.type = "CredentialsSignin";
+    }
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  signIn: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// Mock axios before importing (RegisterUser imports axios inline)
+vi.mock("axios", () => ({
+  default: { isAxiosError: vi.fn(() => false) },
+  isAxiosError: vi.fn(() => false),
+}));
+
+// Mock apiClient to avoid real HTTP calls
+vi.mock("@/services/apiPublic", () => ({
+  default: {
+    post: vi.fn().mockResolvedValue({ data: { id: 1, email: "test@test.com" } }),
+  },
+}));
+
+import { RegisterUser } from "@/actions/auth-actions";
+import type { RegisterInput } from "@/validations/auth/register.schema";
+
+function makeValidInput(): RegisterInput {
+  return {
+    name: "Juan",
+    lastName: "Pérez",
+    email: "juan@example.com",
+    password: "password123",
+    confirmPassword: "password123",
+    phone: "999888777",
+    birthdate: "1990-01-01",
+    document: "DNI",
+    documentNumber: "12345678",
+  };
+}
+
+describe("RegisterUser Zod validation (#59)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns field errors for invalid input (missing email)", async () => {
+    const badInput = { ...makeValidInput(), email: "" };
+    const result = await RegisterUser(badInput);
+
+    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("fieldErrors");
+    expect((result as { error: string; fieldErrors: unknown }).error).toBe(
+      "Hay errores en los datos ingresados"
+    );
+  });
+
+  it("returns field errors when password and confirmPassword mismatch", async () => {
+    const badInput = {
+      ...makeValidInput(),
+      password: "password123",
+      confirmPassword: "different",
+    };
+    const result = await RegisterUser(badInput);
+
+    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("fieldErrors");
+  });
+
+  it("returns field errors for short name", async () => {
+    const badInput = { ...makeValidInput(), name: "A" };
+    const result = await RegisterUser(badInput);
+
+    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("fieldErrors");
+  });
+
+  it("does NOT call the API for invalid input", async () => {
+    const apiClient = await import("@/services/apiPublic");
+    const badInput = { ...makeValidInput(), email: "" };
+    await RegisterUser(badInput);
+
+    expect(apiClient.default.post).not.toHaveBeenCalled();
+  });
+
+  it("returns data for valid input (API call proceeds)", async () => {
+    const validInput = makeValidInput();
+    const result = await RegisterUser(validInput);
+
+    // Valid input should not have validation errors
+    expect(result).not.toHaveProperty("fieldErrors");
+  });
+});

--- a/src/actions/auth-actions.ts
+++ b/src/actions/auth-actions.ts
@@ -52,7 +52,14 @@ import axios from "axios";
 // ... previous code ...
 
 export async function RegisterUser(data: RegisterInput) {
-  // ... validation ...
+  const validatedFields = registerSchema.safeParse(data);
+
+  if (!validatedFields.success) {
+    return {
+      error: "Hay errores en los datos ingresados",
+      fieldErrors: validatedFields.error.flatten(),
+    };
+  }
 
   try {
     const response = await apiClient.post("/api/v2.0/auth/user/create/", data);

--- a/src/app/(private)/dashboard/proformas/__tests__/proformas-boundaries.test.tsx
+++ b/src/app/(private)/dashboard/proformas/__tests__/proformas-boundaries.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Mock useRouter
+const mockRefresh = vi.fn();
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+    push: mockPush,
+  }),
+}));
+
+import ProformasLoading from "@/app/(private)/dashboard/proformas/loading";
+import ProformasError from "@/app/(private)/dashboard/proformas/error";
+
+describe("Proformas loading.tsx (#66)", () => {
+  it("renders a loading indicator", () => {
+    render(<ProformasLoading />);
+    expect(screen.getByText("Cargando proformas...")).toBeInTheDocument();
+  });
+
+  it("renders skeleton placeholders", () => {
+    const { container } = render(<ProformasLoading />);
+    // MUI Skeleton renders <span class="MuiSkeleton-root">
+    const skeletons = container.querySelectorAll(".MuiSkeleton-root");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Proformas error.tsx (#66)", () => {
+  it("renders an error message", () => {
+    const testError = new Error("Test fetch error") as Error & { digest?: string };
+    testError.digest = "abc123";
+    const mockReset = vi.fn();
+
+    render(<ProformasError error={testError} reset={mockReset} />);
+    expect(
+      screen.getByText("Error al cargar proformas")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Reintentar button that calls reset()", () => {
+    const testError = new Error("Test fetch error") as Error & { digest?: string };
+    testError.digest = "abc123";
+    const mockReset = vi.fn();
+
+    render(<ProformasError error={testError} reset={mockReset} />);
+    const retryBtn = screen.getByRole("button", { name: /Reintentar/i });
+    fireEvent.click(retryBtn);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a Recargar button that calls router.refresh()", () => {
+    mockRefresh.mockClear();
+    const testError = new Error("Test fetch error") as Error & { digest?: string };
+    testError.digest = "abc123";
+    const mockReset = vi.fn();
+
+    render(<ProformasError error={testError} reset={mockReset} />);
+    const reloadBtn = screen.getByRole("button", { name: /Recargar/i });
+    fireEvent.click(reloadBtn);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(private)/dashboard/proformas/error.tsx
+++ b/src/app/(private)/dashboard/proformas/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface ProformasErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ProformasError({ error, reset }: ProformasErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar proformas</AlertTitle>
+        No se pudieron cargar las proformas. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/(private)/dashboard/proformas/loading.tsx
+++ b/src/app/(private)/dashboard/proformas/loading.tsx
@@ -1,0 +1,55 @@
+import { Box, CircularProgress, Skeleton, Typography } from "@mui/material";
+
+export default function ProformasLoading() {
+  return (
+    <Box>
+      {/* Header skeleton */}
+      <Box sx={{ mb: 3 }}>
+        <Skeleton variant="text" width={200} height={40} />
+        <Skeleton variant="text" width={320} height={24} sx={{ mt: 0.5 }} />
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 3,
+          flexDirection: { xs: "column", lg: "row" },
+        }}
+      >
+        {/* Create Proforma card skeleton */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Skeleton
+            variant="rounded"
+            height={300}
+            sx={{ borderRadius: 2 }}
+          />
+        </Box>
+
+        {/* List skeleton */}
+        <Box sx={{ flex: 2, minWidth: 0 }}>
+          <Skeleton
+            variant="rounded"
+            height={400}
+            sx={{ borderRadius: 2 }}
+          />
+        </Box>
+      </Box>
+
+      {/* Loading indicator */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 2,
+          mt: 4,
+        }}
+      >
+        <CircularProgress size={24} />
+        <Typography variant="body2" color="text.secondary">
+          Cargando proformas...
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/api/search/__tests__/route.test.ts
+++ b/src/app/api/search/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { GET } from "@/app/api/search/route";
+
+describe("Search API route (#65)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends Content-Type: application/json header', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const request = new Request("http://localhost/api/search?q=laptop");
+    await GET(request);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const fetchCall = mockFetch.mock.calls[0];
+    const fetchOptions = fetchCall[1];
+    expect(fetchOptions.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("does NOT send the typo 'applications/json'", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const request = new Request("http://localhost/api/search?q=laptop");
+    await GET(request);
+
+    const fetchOptions = mockFetch.mock.calls[0][1];
+    expect(fetchOptions.headers["Content-Type"]).not.toBe("applications/json");
+  });
+
+  it("returns empty results when no query is provided", async () => {
+    const request = new Request("http://localhost/api/search");
+    const response = await GET(request);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    const body = await response.json();
+    expect(body).toEqual({ results: [] });
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
       {
         method: "GET",
         headers: {
-          "Content-Type": "applications/json",
+          "Content-Type": "application/json",
           "x-api-key": `${API_KEY}`,
         },
       }

--- a/src/components/catalog/product/search/SearchErrorFallback.tsx
+++ b/src/components/catalog/product/search/SearchErrorFallback.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button, Paper, Typography } from "@mui/material";
+import ErrorIcon from "@mui/icons-material/Error";
+
+interface SearchErrorFallbackProps {
+  message: string;
+}
+
+export function SearchErrorFallback({ message }: SearchErrorFallbackProps) {
+  const router = useRouter();
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 4,
+        textAlign: "center",
+        borderRadius: 4,
+        bgcolor: "#fff",
+        border: "1px solid #e5e7eb",
+      }}
+    >
+      <ErrorIcon color="error" sx={{ fontSize: 60, mb: 2 }} />
+      <Typography
+        variant="h5"
+        color="text.secondary"
+        gutterBottom
+        fontWeight={600}
+      >
+        {message}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" mb={3}>
+        Por favor, intenta recargar la página o vuelve más tarde.
+      </Typography>
+      <Button
+        variant="contained"
+        onClick={() => router.refresh()}
+        sx={{ bgcolor: "#5914A3", "&:hover": { bgcolor: "#450b82" } }}
+      >
+        Recargar
+      </Button>
+    </Paper>
+  );
+}

--- a/src/components/catalog/product/search/__tests__/SearchErrorFallback.test.tsx
+++ b/src/components/catalog/product/search/__tests__/SearchErrorFallback.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Mock useRouter before importing the component
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+import { SearchErrorFallback } from "@/components/catalog/product/search/SearchErrorFallback";
+
+describe("SearchErrorFallback (#61)", () => {
+  it("renders the error message", () => {
+    render(<SearchErrorFallback message="Ocurrió un error al buscar productos." />);
+    expect(
+      screen.getByText("Ocurrió un error al buscar productos.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a recargar button", () => {
+    render(<SearchErrorFallback message="Test error" />);
+    expect(screen.getByRole("button", { name: /Recargar/i })).toBeInTheDocument();
+  });
+
+  it("calls router.refresh() when recargar button is clicked", () => {
+    mockRefresh.mockClear();
+    render(<SearchErrorFallback message="Test error" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Recargar/i }));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses Next.js router.refresh() for navigation, not window.location.reload()", () => {
+    mockRefresh.mockClear();
+    render(<SearchErrorFallback message="Test error" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Recargar/i }));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/catalog/product/search/product-result-list.tsx
+++ b/src/components/catalog/product/search/product-result-list.tsx
@@ -4,8 +4,8 @@ import { GridProduct } from "@/components/catalog/product/grid-product";
 import { PaginationButtons } from "@/components/common/PaginationButtons";
 import { Box, Typography, Button, Paper } from "@mui/material";
 import SearchOffIcon from "@mui/icons-material/SearchOff";
-import ErrorIcon from "@mui/icons-material/Error";
 import Link from "next/link";
+import { SearchErrorFallback } from "./SearchErrorFallback";
 
 interface ProductResultListProps {
     query: string;
@@ -106,36 +106,7 @@ export const ProductResultList = async ({
         );
     } catch (error) {
         return (
-            <Paper
-                elevation={0}
-                sx={{
-                    p: 4,
-                    textAlign: "center",
-                    borderRadius: 4,
-                    bgcolor: "#fff",
-                    border: "1px solid #e5e7eb",
-                }}
-            >
-                <ErrorIcon color="error" sx={{ fontSize: 60, mb: 2 }} />
-                <Typography
-                    variant="h5"
-                    color="text.secondary"
-                    gutterBottom
-                    fontWeight={600}
-                >
-                    Ocurrió un error al buscar productos.
-                </Typography>
-                <Typography variant="body1" color="text.secondary" mb={3}>
-                    Por favor, intenta recargar la página o vuelve más tarde.
-                </Typography>
-                <Button
-                    variant="contained"
-                    onClick={() => window.location.reload()} // Simple reload
-                    sx={{ bgcolor: "#5914A3", "&:hover": { bgcolor: "#450b82" } }}
-                >
-                    Recargar
-                </Button>
-            </Paper>
+            <SearchErrorFallback message="Ocurrió un error al buscar productos." />
         );
     }
 };

--- a/src/components/dashboard/DashboardBottomNav.tsx
+++ b/src/components/dashboard/DashboardBottomNav.tsx
@@ -9,8 +9,6 @@ import {
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import PersonIcon from "@mui/icons-material/Person";
 import MenuIcon from "@mui/icons-material/Menu";
-import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
-import EngineeringIcon from "@mui/icons-material/Engineering";
 import ReceiptIcon from "@mui/icons-material/Receipt";
 import { User } from "next-auth";
 
@@ -23,26 +21,13 @@ export function DashboardBottomNav({ user, onMenuClick }: DashboardBottomNavProp
   const pathname = usePathname();
   const router = useRouter();
 
-  // Determine dynamic third action based on role
-  let dynamicAction = {
+  // Use hardcoded /dashboard/invoices always — /dashboard/sales and /dashboard/tech
+  // do not exist yet. The role-based dynamic path can be restored when those routes are built.
+  const dynamicAction = {
     label: "Facturas",
     icon: <ReceiptIcon />,
     path: "/dashboard/invoices",
   };
-
-  if (user.isSeller || user.isAdmin || user.isSuperuser) {
-    dynamicAction = {
-      label: "Ventas",
-      icon: <ShoppingCartIcon />,
-      path: "/dashboard/sales",
-    };
-  } else if (user.isTechnician) {
-    dynamicAction = {
-      label: "Servicio",
-      icon: <EngineeringIcon />,
-      path: "/dashboard/tech",
-    };
-  }
 
   // Handle navigation internally so BottomNavigation can use standard 'value' logic
   const handleChange = (event: React.SyntheticEvent, newValue: string) => {

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -70,13 +70,13 @@ export const DashboardSidebar = ({
           label: "Usuarios",
           icon: <PeopleIcon />,
           path: "/dashboard/users",
-          visible: user?.isAdmin,
+          visible: false, // TODO: habilitar cuando la ruta exista
         },
         {
           label: "Configuración",
           icon: <SettingsIcon />,
           path: "/dashboard/settings",
-          visible: user?.isAdmin,
+          visible: false, // TODO: habilitar cuando la ruta exista
         },
         {
           label: "Banners",
@@ -93,7 +93,7 @@ export const DashboardSidebar = ({
           label: "Ventas",
           icon: <ShoppingCartIcon />,
           path: "/dashboard/sales",
-          visible: user?.isAdmin || user?.isSeller,
+          visible: false, // TODO: habilitar cuando la ruta exista
         },
         {
           label: "Proformas",
@@ -105,13 +105,13 @@ export const DashboardSidebar = ({
           label: "Ordenes",
           icon: <LocalShippingIcon />,
           path: "/dashboard/ordenes",
-          visible: user?.isAdmin || user?.isSeller,
+          visible: false, // TODO: habilitar cuando la ruta exista
         },
         {
           label: "Servicio Técnico",
           icon: <EngineeringIcon />,
           path: "/dashboard/tech",
-          visible: user?.isAdmin || user?.isTechnician,
+          visible: false, // TODO: habilitar cuando la ruta exista
         },
       ],
     },

--- a/src/components/dashboard/__tests__/DashboardBottomNav.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardBottomNav.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock usePathname and useRouter
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { DashboardBottomNav } from "@/components/dashboard/DashboardBottomNav";
+import type { User } from "next-auth";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    name: "Admin User",
+    email: "admin@example.com",
+    isAdmin: true,
+    ...overrides,
+  } as unknown as User;
+}
+
+describe("DashboardBottomNav dead links (#60)", () => {
+  it("does NOT render 'Ventas' link (route /dashboard/sales does not exist)", () => {
+    const user = makeUser({ isAdmin: true, isSeller: true });
+    render(<DashboardBottomNav user={user} onMenuClick={vi.fn()} />);
+    expect(screen.queryByText("Ventas")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render 'Servicio' link for technician user", () => {
+    const user = makeUser({ isTechnician: true });
+    render(<DashboardBottomNav user={user} onMenuClick={vi.fn()} />);
+    expect(screen.queryByText("Servicio")).not.toBeInTheDocument();
+  });
+
+  it('always renders "Facturas" as the third action', () => {
+    const user = makeUser({ isAdmin: true, isSeller: true });
+    render(<DashboardBottomNav user={user} onMenuClick={vi.fn()} />);
+    expect(screen.getByText("Facturas")).toBeInTheDocument();
+  });
+
+  it("renders 'Inicio' and 'Perfil' links", () => {
+    const user = makeUser();
+    render(<DashboardBottomNav user={user} onMenuClick={vi.fn()} />);
+    expect(screen.getByText("Inicio")).toBeInTheDocument();
+    expect(screen.getByText("Perfil")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/__tests__/DashboardSidebar.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardSidebar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+import type { User } from "next-auth";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    name: "Admin User",
+    email: "admin@example.com",
+    isAdmin: true,
+    ...overrides,
+  } as unknown as User;
+}
+
+describe("DashboardSidebar dead links (#62)", () => {
+  it("hides 'Usuarios' link (route /dashboard/users does not exist)", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.queryByText("Usuarios")).not.toBeInTheDocument();
+  });
+
+  it("hides 'Configuración' link (route /dashboard/settings does not exist)", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.queryByText("Configuración")).not.toBeInTheDocument();
+  });
+
+  it("hides 'Ventas' link (route /dashboard/sales does not exist)", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.queryByText("Ventas")).not.toBeInTheDocument();
+  });
+
+  it("hides 'Ordenes' link (route /dashboard/ordenes does not exist)", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.queryByText("Ordenes")).not.toBeInTheDocument();
+  });
+
+  it("hides 'Servicio Técnico' link (route /dashboard/tech does not exist)", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.queryByText("Servicio Técnico")).not.toBeInTheDocument();
+  });
+
+  it("still shows 'Panel Principal' link", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.getByText("Panel Principal")).toBeInTheDocument();
+  });
+
+  it("still shows 'Proformas' link for admin/seller users", () => {
+    const user = makeUser({ isAdmin: true, isSeller: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.getByText("Proformas")).toBeInTheDocument();
+  });
+
+  it("still shows 'Mis Facturas' link", () => {
+    const user = makeUser({ isAdmin: true });
+    render(<DashboardSidebar user={user} />);
+    expect(screen.getByText("Mis Facturas")).toBeInTheDocument();
+  });
+});

--- a/src/config/__tests__/roles.test.ts
+++ b/src/config/__tests__/roles.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { ROLE_PERMISSIONS } from "@/config/roles";
+
+describe("ROLE_PERMISSIONS", () => {
+  it('EDITOR permission includes "dashboard.view" (#64)', () => {
+    expect(ROLE_PERMISSIONS.EDITOR).toEqual(["dashboard.view", "products.manage"]);
+  });
+
+  it("does not contain the typo 'desboard.view'", () => {
+    const perms = ROLE_PERMISSIONS.EDITOR;
+    expect(perms.some((p) => p.includes("desboard"))).toBe(false);
+  });
+});

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -20,6 +20,6 @@ export const ROLE_PERMISSIONS: Record<Role, string[]> = {
   STAFF: ["dashboard.view", "orders.view", "orders.manage"],
   SELLER: ["orders.manage", "products.manage"],
   TECHNICIAN: ["tickets.view", "tickets.update"],
-  EDITOR: ["desboard.view", "products.manage"],
+  EDITOR: ["dashboard.view", "products.manage"],
   CUSTOMER: ["orders.view", "profile.update"],
 };

--- a/src/lib/__tests__/getUserRoles.test.ts
+++ b/src/lib/__tests__/getUserRoles.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { getUserRoles } from "@/lib/getUserRoles";
+import type { JWT } from "next-auth/jwt";
+
+function makeToken(overrides: Record<string, unknown> = {}): JWT {
+  return {
+    name: "Test User",
+    email: "test@example.com",
+    sub: "123",
+    accessToken: "fake-access-token",
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    jti: "jti-123",
+    ...overrides,
+  } as unknown as JWT;
+}
+
+describe("getUserRoles", () => {
+  it('includes EDITOR when token.isEditor is true (#63)', () => {
+    const token = makeToken({ isEditor: true });
+    const roles = getUserRoles(token);
+    expect(roles).toContain("EDITOR");
+  });
+
+  it("does NOT include EDITOR when token.isEditor is false", () => {
+    const token = makeToken({ isEditor: false });
+    const roles = getUserRoles(token);
+    expect(roles).not.toContain("EDITOR");
+  });
+
+  it("does NOT include EDITOR when token.isEditor is undefined", () => {
+    const token = makeToken({});
+    const roles = getUserRoles(token);
+    expect(roles).not.toContain("EDITOR");
+  });
+
+  it("EDITOR coexists with other roles", () => {
+    const token = makeToken({ isEditor: true, isAdmin: true, isSeller: true });
+    const roles = getUserRoles(token);
+    expect(roles).toContain("ADMIN");
+    expect(roles).toContain("SELLER");
+    expect(roles).toContain("EDITOR");
+  });
+});

--- a/src/lib/getUserRoles.ts
+++ b/src/lib/getUserRoles.ts
@@ -8,6 +8,7 @@ export function getUserRoles(token: JWT): Role[] {
   if (token.isStaff) roles.push("STAFF");
   if (token.isSeller) roles.push("SELLER");
   if (token.isTechnician) roles.push("TECHNICIAN");
+  if (token.isEditor) roles.push("EDITOR");
   if (token.isCustomer) roles.push("CUSTOMER");
 
   return roles;


### PR DESCRIPTION
## Summary

Eight isolated bug fixes and improvements across the app:

### Fixes
- **#59** — Add Zod `safeParse` validation to `RegisterUser` action (mirrors `loginAction` pattern)
- **#63** — Add `EDITOR` role mapping in `getUserRoles`
- **#64** — Fix typo `desboard.view` -> `dashboard.view` in `ROLE_PERMISSIONS`
- **#65** — Fix `applications/json` -> `application/json` Content-Type header in search API
- **#60** — Remove dead links from `DashboardBottomNav` (sales, tech routes don't exist)
- **#62** — Hide 5 dead links in `DashboardSidebar` with `visible: false`
- **#61** — Replace `window.location.reload()` with `useRouter().refresh()` in product search error UI
- **#66** — Add `loading.tsx` and `error.tsx` to `/dashboard/proformas`

### Verification
- [x] 69 tests pass (`npx vitest run`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] All fixes isolated per file — safe to revert individually

Closes #59, closes #60, closes #61, closes #62, closes #63, closes #64, closes #65, closes #66
