### PR TITLE
feat(ux): EmptyState component + stub pages (PR 1/4 - Stacked to main)

### DIFF
--- a/src/app/(site)/categorias/page.tsx
+++ b/src/app/(site)/categorias/page.tsx
@@ -1,0 +1,25 @@
+import { Container, Box, Typography } from "@mui/material";
+
+export const metadata = {
+  title: "Categorías | Corporacion Luana",
+  description: "Sección de categorías próximamente disponible",
+};
+
+export default function CategoriasPage() {
+  return (
+    <Container maxWidth="xl">
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "60vh",
+        }}
+      >
+        <Typography variant="h3" color="text.secondary" fontWeight={700}>
+          Próximamente
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/(site)/clientes/page.tsx
+++ b/src/app/(site)/clientes/page.tsx
@@ -1,0 +1,25 @@
+import { Container, Box, Typography } from "@mui/material";
+
+export const metadata = {
+  title: "Clientes | Corporacion Luana",
+  description: "Sección de clientes próximamente disponible",
+};
+
+export default function ClientesPage() {
+  return (
+    <Container maxWidth="xl">
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "60vh",
+        }}
+      >
+        <Typography variant="h3" color="text.secondary" fontWeight={700}>
+          Próximamente
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/(site)/pedidos/page.tsx
+++ b/src/app/(site)/pedidos/page.tsx
@@ -1,0 +1,25 @@
+import { Container, Box, Typography } from "@mui/material";
+
+export const metadata = {
+  title: "Pedidos | Corporacion Luana",
+  description: "Sección de pedidos próximamente disponible",
+};
+
+export default function PedidosPage() {
+  return (
+    <Container maxWidth="xl">
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "60vh",
+        }}
+      >
+        <Typography variant="h3" color="text.secondary" fontWeight={700}>
+          Próximamente
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React from "react";
+import { Box, Typography, Button, Paper } from "@mui/material";
+import SearchOffIcon from "@mui/icons-material/SearchOff";
+import Link from "next/link";
+
+export interface EmptyStateAction {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}
+
+export interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description: string;
+  primaryAction?: EmptyStateAction;
+  secondaryAction?: EmptyStateAction;
+}
+
+const defaultIcon = (
+  <SearchOffIcon sx={{ fontSize: 80, color: "#d1d5db", mb: 2 }} />
+);
+
+const defaultPrimaryAction: EmptyStateAction = {
+  label: "Volver al catálogo",
+  href: "/",
+};
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  icon = defaultIcon,
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+}) => {
+  const primary = primaryAction ?? defaultPrimaryAction;
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 6,
+        textAlign: "center",
+        borderRadius: 4,
+        bgcolor: "#fff",
+        border: "1px dashed #e5e7eb",
+      }}
+    >
+      {icon}
+      <Typography variant="h4" color="#545454" fontWeight={700} gutterBottom>
+        {title}
+      </Typography>
+      <Typography
+        variant="body1"
+        color="text.secondary"
+        sx={{ maxWidth: 600, mx: "auto", mb: 4 }}
+      >
+        {description}
+      </Typography>
+      <Box sx={{ display: "flex", justifyContent: "center", gap: 2, flexWrap: "wrap" }}>
+        {primary.href != null && primary.href !== undefined ? (
+          <Link href={primary.href} passHref style={{ textDecoration: "none" }}>
+            <Button
+              variant="contained"
+              size="large"
+              sx={{
+                bgcolor: "#A3147F",
+                borderRadius: 50,
+                px: 4,
+                "&:hover": { bgcolor: "#800e63" },
+              }}
+            >
+              {primary.label}
+            </Button>
+          </Link>
+        ) : (
+          <Button
+            variant="contained"
+            size="large"
+            onClick={primary.onClick}
+            sx={{
+              bgcolor: "#A3147F",
+              borderRadius: 50,
+              px: 4,
+              "&:hover": { bgcolor: "#800e63" },
+            }}
+          >
+            {primary.label}
+          </Button>
+        )}
+
+        {secondaryAction && (
+          secondaryAction.href != null && secondaryAction.href !== undefined ? (
+            <Link href={secondaryAction.href} passHref style={{ textDecoration: "none" }}>
+              <Button
+                variant="outlined"
+                size="large"
+                sx={{
+                  borderColor: "#A3147F",
+                  color: "#A3147F",
+                  borderRadius: 50,
+                  px: 4,
+                  "&:hover": {
+                    borderColor: "#800e63",
+                    bgcolor: "rgba(163, 20, 127, 0.04)",
+                  },
+                }}
+              >
+                {secondaryAction.label}
+              </Button>
+            </Link>
+          ) : (
+            <Button
+              variant="outlined"
+              size="large"
+              onClick={secondaryAction.onClick}
+              sx={{
+                borderColor: "#A3147F",
+                color: "#A3147F",
+                borderRadius: 50,
+                px: 4,
+                "&:hover": {
+                  borderColor: "#800e63",
+                  bgcolor: "rgba(163, 20, 127, 0.04)",
+                },
+              }}
+            >
+              {secondaryAction.label}
+            </Button>
+          )
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default EmptyState;

--- a/src/components/shared/__tests__/EmptyState.test.tsx
+++ b/src/components/shared/__tests__/EmptyState.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { EmptyState } from "@/components/shared/EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title (message)", () => {
+    render(
+      <EmptyState
+        title="Sin resultados para test"
+        description="No se encontraron productos."
+      />
+    );
+    expect(
+      screen.getByText("Sin resultados para test")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the description text", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción de prueba"
+      />
+    );
+    expect(
+      screen.getByText("Descripción de prueba")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the default primary action button", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+      />
+    );
+    expect(
+      screen.getByRole("link", { name: /Volver al catálogo/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders both primary and secondary actions when provided", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+        primaryAction={{ label: "Ir al inicio", href: "/" }}
+        secondaryAction={{ label: "Limpiar filtros", onClick: () => {} }}
+      />
+    );
+    expect(
+      screen.getByRole("link", { name: /Ir al inicio/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Limpiar filtros/i })
+    ).toBeInTheDocument();
+  });
+
+  it("primary action link has the correct href", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+        primaryAction={{ label: "Explorar Catálogo", href: "/productos" }}
+      />
+    );
+    const link = screen.getByRole("link", { name: /Explorar Catálogo/i });
+    expect(link).toHaveAttribute("href", "/productos");
+  });
+
+  it("secondary action fires onClick when clicked", () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+        secondaryAction={{ label: "Limpiar", onClick: handleClick }}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /Limpiar/i });
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a custom icon when provided", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+        icon={<span data-testid="custom-icon">🎨</span>}
+      />
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
+  it("does not render secondary action when not provided", () => {
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+      />
+    );
+    // Primary action with href renders inside a link (anchor tag wrapping a button)
+    expect(
+      screen.getByRole("link", { name: /Volver al catálogo/i })
+    ).toBeInTheDocument();
+    // Secondary action should NOT be present
+    expect(
+      screen.queryByRole("button", { name: /Limpiar filtros/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders primary action as button when onClick is used instead of href", () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyState
+        title="Título"
+        description="Descripción"
+        primaryAction={{ label: "Hacer algo", onClick: handleClick }}
+      />
+    );
+    const button = screen.getByRole("button", { name: /Hacer algo/i });
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## PR 1/4 — Stacked to main

Part of `ux-improvements` change (PRs stacked to main).

### What this does
- Creates a shared `<EmptyState>` component with configurable icon, title, description, primary action, and secondary action
- Creates stub `page.tsx` files for 3 nonexistent routes: `categorias`, `pedidos`, `clientes`

### Files changed
| File | Action | Description |
|------|--------|-------------|
| `src/components/shared/EmptyState.tsx` | New | Reusable empty-state client component |
| `src/components/shared/__tests__/EmptyState.test.tsx` | New | 9 unit tests |
| `src/app/(site)/categorias/page.tsx` | New | Stub page - "Próximamente" |
| `src/app/(site)/pedidos/page.tsx` | New | Stub page - "Próximamente" |
| `src/app/(site)/clientes/page.tsx` | New | Stub page - "Próximamente" |

### Verification
- `npx vitest run` — 78/78 tests pass (9 new)

### Stacked PR plan
1. ✅ PR#1: EmptyState + stub pages (this PR) → `main`
2. 🔲 PR#2: Dashboard loading skeletons → `main`
3. 🔲 PR#3: Error boundaries (global + per-route) → `main`
4. 🔲 PR#4: Search loading indicator + wire EmptyState into existing components → `main`
