### PR TITLE
feat(ux): add error boundaries for 5 routes + global catch-all

### DIFF
--- a/src/__tests__/error-boundaries.test.tsx
+++ b/src/__tests__/error-boundaries.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Mock useRouter
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+import GlobalError from "@/app/error";
+import ProductosError from "@/app/(site)/productos/error";
+import MarcasError from "@/app/(site)/marcas/error";
+
+describe("Global error boundary", () => {
+  it("renders error message and retry buttons", () => {
+    render(<GlobalError error={new Error("test")} reset={() => {}} />);
+
+    expect(screen.getByText("Error inesperado")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Ocurrió un error inesperado. Por favor, intenta de nuevo."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reintentar/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Recargar/i })
+    ).toBeInTheDocument();
+  });
+
+  it("Renders Alert with error severity", () => {
+    render(<GlobalError error={new Error("test")} reset={() => {}} />);
+
+    // MUI Alert with severity="error" renders with role="alert"
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+  });
+
+  it("Reintentar button calls reset()", () => {
+    const mockReset = vi.fn();
+    render(<GlobalError error={new Error("test")} reset={mockReset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Reintentar/i }));
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("Recargar button calls router.refresh()", () => {
+    mockRefresh.mockClear();
+    render(<GlobalError error={new Error("test")} reset={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Recargar/i }));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Route error boundaries", () => {
+  it("Productos error renders with correct messages and buttons", () => {
+    render(<ProductosError error={new Error("test")} reset={() => {}} />);
+
+    expect(screen.getByText("Error al cargar productos")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No se pudieron cargar los productos. Por favor, intenta de nuevo."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reintentar/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Recargar/i })
+    ).toBeInTheDocument();
+  });
+
+  it("Marcas error renders with correct messages and buttons", () => {
+    render(<MarcasError error={new Error("test")} reset={() => {}} />);
+
+    expect(screen.getByText("Error al cargar marcas")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No se pudieron cargar las marcas. Por favor, intenta de nuevo."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reintentar/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Recargar/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(site)/categorias/error.tsx
+++ b/src/app/(site)/categorias/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface CategoriasErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function CategoriasError({ error, reset }: CategoriasErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar categorías</AlertTitle>
+        No se pudieron cargar las categorías. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/(site)/clientes/error.tsx
+++ b/src/app/(site)/clientes/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface ClientesErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ClientesError({ error, reset }: ClientesErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar clientes</AlertTitle>
+        No se pudieron cargar los clientes. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/(site)/marcas/error.tsx
+++ b/src/app/(site)/marcas/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface MarcasErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function MarcasError({ error, reset }: MarcasErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar marcas</AlertTitle>
+        No se pudieron cargar las marcas. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/(site)/pedidos/error.tsx
+++ b/src/app/(site)/pedidos/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface PedidosErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function PedidosError({ error, reset }: PedidosErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar pedidos</AlertTitle>
+        No se pudieron cargar los pedidos. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/(site)/productos/error.tsx
+++ b/src/app/(site)/productos/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface ProductosErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ProductosError({ error, reset }: ProductosErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error al cargar productos</AlertTitle>
+        No se pudieron cargar los productos. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: 400,
+      }}
+    >
+      <Alert
+        severity="error"
+        variant="outlined"
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+          borderRadius: 2,
+        }}
+        action={
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => reset()}
+              startIcon={<RefreshIcon />}
+            >
+              Reintentar
+            </Button>
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => router.refresh()}
+            >
+              Recargar
+            </Button>
+          </Box>
+        }
+      >
+        <AlertTitle>Error inesperado</AlertTitle>
+        Ocurrió un error inesperado. Por favor, intenta de nuevo.
+      </Alert>
+    </Box>
+  );
+}


### PR DESCRIPTION
## PR 3/4 — Stacked to main

### What
Adds error boundaries across the app following the established proformas pattern (Alert + Reintentar + Recargar buttons).

### Changes
- `src/app/error.tsx` — Global error boundary at the root layout level
- 5 per-route error.tsx: productos, marcas, categorias, pedidos, clientes
- All follow identical pattern: MUI Alert with severity="error", centered layout, Reintentar (reset) + Recargar (router.refresh) buttons
- 6 new tests: global boundary renders + button interactions, productos + marcas route boundaries

### Test results
 Test Files  20 passed (20)
      Tests  92 passed (92)

### Stack
- Targets: ux/pr-02-loading
- Previous: PR#1 ux/pr-01-empty-state (#86), PR#2 ux/pr-02-loading (#87)