### PR TITLE
feat(ux): search loading indicator + EmptyState wiring

### DIFF
--- a/src/__tests__/search-loading-empty.test.tsx
+++ b/src/__tests__/search-loading-empty.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+
+// ── Mock next/navigation —──────────────────────────────────────────
+let searchParamsValue: URLSearchParams;
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsValue,
+  usePathname: () => "/buscar",
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+import { SearchLoadingProgress } from "@/components/catalog/product/search/search-loading-progress";
+
+// ── Mock product services —─────────────────────────────────────────
+const mockFetchProductSearchList = vi.fn();
+const mockFetchExchangeRate = vi.fn();
+
+vi.mock("@/services/catalog/products", () => ({
+  fetchProductSearchList: (...args: any[]) => mockFetchProductSearchList(...args),
+}));
+
+vi.mock("@/services/catalog/exchangeRate", () => ({
+  fetchExchangeRate: (...args: any[]) => mockFetchExchangeRate(...args),
+}));
+
+import { ProductResultList } from "@/components/catalog/product/search/product-result-list";
+
+describe("SearchLoadingProgress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    searchParamsValue = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show LinearProgress before 300ms", () => {
+    const { rerender } = render(<SearchLoadingProgress />);
+
+    // Change search params (simulate user changing a filter)
+    searchParamsValue = new URLSearchParams("query=test");
+    rerender(<SearchLoadingProgress />);
+
+    // Advance 200ms — still under the 300ms debounce threshold
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // LinearProgress should NOT be visible yet
+    expect(
+      document.querySelector(".MuiLinearProgress-root")
+    ).toBeNull();
+  });
+
+  it("shows LinearProgress after 300ms debounce", () => {
+    const { rerender } = render(<SearchLoadingProgress />);
+
+    // Change search params
+    searchParamsValue = new URLSearchParams("ordering=price_sale");
+    rerender(<SearchLoadingProgress />);
+
+    // Advance past the 300ms debounce threshold
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+
+    // LinearProgress should now be visible
+    expect(
+      document.querySelector(".MuiLinearProgress-root")
+    ).toBeInTheDocument();
+  });
+
+  it("hides the indicator when new params arrive before debounce fires", () => {
+    const { rerender } = render(<SearchLoadingProgress />);
+
+    // First param change
+    searchParamsValue = new URLSearchParams("marca=nike");
+    rerender(<SearchLoadingProgress />);
+
+    // 200ms later, another param change (user clicks another filter)
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    searchParamsValue = new URLSearchParams("marca=nike,adidas");
+    rerender(<SearchLoadingProgress />);
+
+    // Advance past the 300ms window from the SECOND change
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+
+    // Should show after the second change settles
+    expect(
+      document.querySelector(".MuiLinearProgress-root")
+    ).toBeInTheDocument();
+  });
+
+  it("auto-hides after 5 seconds", () => {
+    const { rerender } = render(<SearchLoadingProgress />);
+
+    searchParamsValue = new URLSearchParams("query=x");
+    rerender(<SearchLoadingProgress />);
+
+    // Show the indicator
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+    expect(
+      document.querySelector(".MuiLinearProgress-root")
+    ).toBeInTheDocument();
+
+    // Advance past the 5s auto-hide
+    act(() => {
+      vi.advanceTimersByTime(5001);
+    });
+
+    expect(
+      document.querySelector(".MuiLinearProgress-root")
+    ).toBeNull();
+  });
+});
+
+describe("ProductResultList — empty state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders EmptyState when search returns zero results", async () => {
+    mockFetchProductSearchList.mockResolvedValue({
+      results: [],
+      count: 0,
+    });
+    mockFetchExchangeRate.mockResolvedValue({
+      exchange: 1.0,
+    });
+
+    // ProductResultList is an async server component
+    const element = await ProductResultList({
+      query: "nonexistent",
+      page: 1,
+    });
+
+    render(element as React.ReactElement);
+
+    // EmptyState title
+    expect(
+      screen.getByText('Sin resultados para "nonexistent"')
+    ).toBeInTheDocument();
+
+    // EmptyState description
+    expect(
+      screen.getByText(/No encontramos productos que coincidan con tu búsqueda/i)
+    ).toBeInTheDocument();
+
+    // Primary action — "Volver al catálogo"
+    const primaryLink = screen.getByRole("link", {
+      name: /Volver al catálogo/i,
+    });
+    expect(primaryLink).toHaveAttribute("href", "/productos");
+
+    // Secondary action — "Limpiar filtros"
+    const secondaryLink = screen.getByRole("link", {
+      name: /Limpiar filtros/i,
+    });
+    expect(secondaryLink).toHaveAttribute("href", "/buscar");
+  });
+
+  it("both action buttons are present in the empty state", async () => {
+    mockFetchProductSearchList.mockResolvedValue({
+      results: [],
+      count: 0,
+    });
+    mockFetchExchangeRate.mockResolvedValue({
+      exchange: 1.0,
+    });
+
+    const element = await ProductResultList({
+      query: "empty",
+      page: 1,
+    });
+
+    render(element as React.ReactElement);
+
+    // Both actions should be rendered
+    expect(
+      screen.getByRole("link", { name: /Volver al catálogo/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Limpiar filtros/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(site)/buscar/page.tsx
+++ b/src/app/(site)/buscar/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/skeleton/search-skeletons";
 import { MobileFilterWrapper } from "@/components/catalog/product/search/mobile-filter-wrapper";
 import { ProductSortSelect } from "@/components/catalog/product/search/product-sort-select";
+import { SearchLoadingProgress } from "@/components/catalog/product/search/search-loading-progress";
 
 export const revalidate = 0;
 
@@ -43,6 +44,9 @@ export default async function SearchPage({ searchParams }: SearchParamsProps) {
 
   return (
     <Container maxWidth="xl" sx={{ py: 4, px: { xs: 0, sm: 2 } }}>
+      {/* Loading indicator for filter/sort transitions */}
+      <SearchLoadingProgress />
+
       {/* Header Results Info */}
       <Paper
         elevation={0}

--- a/src/components/catalog/product/search/product-result-list.tsx
+++ b/src/components/catalog/product/search/product-result-list.tsx
@@ -2,9 +2,8 @@ import { fetchProductSearchList } from "@/services/catalog/products";
 import { fetchExchangeRate } from "@/services/catalog/exchangeRate";
 import { GridProduct } from "@/components/catalog/product/grid-product";
 import { PaginationButtons } from "@/components/common/PaginationButtons";
-import { Box, Typography, Button, Paper } from "@mui/material";
-import SearchOffIcon from "@mui/icons-material/SearchOff";
-import Link from "next/link";
+import { Box, Typography } from "@mui/material";
+import { EmptyState } from "@/components/shared/EmptyState";
 import { SearchErrorFallback } from "./SearchErrorFallback";
 
 interface ProductResultListProps {
@@ -36,43 +35,12 @@ export const ProductResultList = async ({
 
         if (!searchProduct || searchProduct.results.length === 0) {
             return (
-                <Paper
-                    elevation={0}
-                    sx={{
-                        p: 6,
-                        textAlign: "center",
-                        borderRadius: 4,
-                        bgcolor: "#fff",
-                        border: "1px dashed #e5e7eb",
-                    }}
-                >
-                    <SearchOffIcon sx={{ fontSize: 80, color: "#d1d5db", mb: 2 }} />
-                    <Typography variant="h4" color="#545454" fontWeight={700} gutterBottom>
-                        Sin resultados para "{query}"
-                    </Typography>
-                    <Typography
-                        variant="body1"
-                        color="text.secondary"
-                        sx={{ maxWidth: 600, mx: "auto", mb: 4 }}
-                    >
-                        No encontramos productos que coincidan con tu búsqueda. Intenta
-                        revisar la ortografía o usar términos más generales.
-                    </Typography>
-                    <Link href="/" passHref style={{ textDecoration: "none" }}>
-                        <Button
-                            variant="contained"
-                            size="large"
-                            sx={{
-                                bgcolor: "#A3147F",
-                                borderRadius: 50,
-                                px: 4,
-                                "&:hover": { bgcolor: "#800e63" },
-                            }}
-                        >
-                            Explorar Catálogo General
-                        </Button>
-                    </Link>
-                </Paper>
+                <EmptyState
+                    title={`Sin resultados para "${query}"`}
+                    description="No encontramos productos que coincidan con tu búsqueda. Intenta revisar la ortografía o usar términos más generales."
+                    primaryAction={{ label: "Volver al catálogo", href: "/productos" }}
+                    secondaryAction={{ label: "Limpiar filtros", href: "/buscar" }}
+                />
             );
         }
 

--- a/src/components/catalog/product/search/search-loading-progress.tsx
+++ b/src/components/catalog/product/search/search-loading-progress.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { LinearProgress, Box } from "@mui/material";
+
+export function SearchLoadingProgress() {
+  const searchParams = useSearchParams();
+  const [show, setShow] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const mountedRef = useRef(false);
+
+  const paramsKey = searchParams.toString();
+
+  useEffect(() => {
+    // Skip the initial mount — only react to subsequent param changes
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+
+    // Clear any pending debounce timer
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    // Immediately hide any existing indicator
+    setShow(false);
+
+    // After 300ms of no further param changes, show the loading indicator
+    debounceRef.current = setTimeout(() => {
+      setShow(true);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [paramsKey]);
+
+  // Auto-hide after 5 seconds as a safety net
+  useEffect(() => {
+    if (!show) return;
+
+    const autoHide = setTimeout(() => {
+      setShow(false);
+    }, 5000);
+
+    return () => clearTimeout(autoHide);
+  }, [show]);
+
+  if (!show) return null;
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        position: "sticky",
+        top: 0,
+        zIndex: 1100,
+      }}
+    >
+      <LinearProgress
+        sx={{
+          height: 4,
+          "& .MuiLinearProgress-bar": {
+            bgcolor: "#A3147F",
+          },
+        }}
+      />
+    </Box>
+  );
+}
+
+export default SearchLoadingProgress;

--- a/src/components/catalog/product/subcategory/subcategory-product-list.tsx
+++ b/src/components/catalog/product/subcategory/subcategory-product-list.tsx
@@ -3,9 +3,8 @@ import { fetchExchangeRate } from "@/services/catalog/exchangeRate";
 import { GridProduct } from "@/components/catalog/product/grid-product";
 import { PaginationButtons } from "@/components/common/PaginationButtons";
 import { Box, Typography, Button, Paper, Container } from "@mui/material";
-import SearchOffIcon from "@mui/icons-material/SearchOff";
+import { EmptyState } from "@/components/shared/EmptyState";
 import ErrorIcon from "@mui/icons-material/Error";
-import Link from "next/link";
 import { startCase } from "lodash";
 
 interface SubCategoryProductListProps {
@@ -38,48 +37,12 @@ export const SubCategoryProductList = async ({
             if (isEmpty) {
                 return (
                     <Container maxWidth="xl" sx={{ mt: 8, mb: 8, px: { xs: 2, sm: 2 } }}>
-                        <Paper
-                            elevation={0}
-                            sx={{
-                                p: 6,
-                                textAlign: "center",
-                                borderRadius: 4,
-                                bgcolor: "#fff",
-                                border: "1px dashed #e5e7eb",
-                            }}
-                        >
-                            <SearchOffIcon sx={{ fontSize: 80, color: "#d1d5db", mb: 2 }} />
-                            <Typography
-                                variant="h4"
-                                color="#545454"
-                                fontWeight={700}
-                                gutterBottom
-                            >
-                                No hay productos en esta categoría
-                            </Typography>
-                            <Typography
-                                variant="body1"
-                                color="text.secondary"
-                                sx={{ maxWidth: 600, mx: "auto", mb: 4 }}
-                            >
-                                Actualmente no tenemos stock disponible para{" "}
-                                {startCase(subcategorySlug)}. Por favor revisa otras categorías.
-                            </Typography>
-                            <Link href="/" passHref style={{ textDecoration: "none" }}>
-                                <Button
-                                    variant="contained"
-                                    size="large"
-                                    sx={{
-                                        bgcolor: "#A3147F",
-                                        borderRadius: 50,
-                                        px: 4,
-                                        "&:hover": { bgcolor: "#800e63" },
-                                    }}
-                                >
-                                    Volver al Inicio
-                                </Button>
-                            </Link>
-                        </Paper>
+                        <EmptyState
+                            title="No hay productos en esta categoría"
+                            description={`Actualmente no tenemos stock disponible para ${startCase(subcategorySlug)}. Por favor revisa otras categorías.`}
+                            primaryAction={{ label: "Volver al catálogo", href: "/productos" }}
+                            secondaryAction={{ label: "Limpiar filtros", href: `/catalogo/${categorySlug}/${subcategorySlug}` }}
+                        />
                     </Container>
                 );
             }


### PR DESCRIPTION
## PR 4/4 FINAL - Stacked to main

### Changes
- **Search loading indicator (#70)**: Added `SearchLoadingProgress` component with 300ms debounce using `useSearchParams`. Shows MUI `LinearProgress` during search filter/sort transitions, auto-hides after 5s.
- **Wire EmptyState (#71)**: Replaced inline empty state in `ProductResultList` and `SubCategoryProductList` with the shared `EmptyState` component with "Volver al catalogo" and "Limpiar filtros" actions.

### Tests (6 new)
- SearchLoadingProgress debounce behavior (before 300ms, after 300ms, rapid changes)
- SearchLoadingProgress auto-hide after 5s
- ProductResultList renders EmptyState when empty with correct action links

### Verification
- `npx vitest run` - 98/98 pass (21 test files)
- `npx tsc --noEmit` - clean

### Stack
PR#1 -> main [OK] | PR#2 -> main [OK] | PR#3 -> main [OK] | **PR#4 -> main [NEW]**