### PR TITLE
fix: increase Node heap to 1GB to prevent OOM crash on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,14 +33,18 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             
-            # Instalar las dependencias de producción
+            # Instalar todas las dependencias (incluye devDeps para el build)
             pnpm install
             
-            # Compilar el proyecto Next.js
+            # Compilar el proyecto Next.js con heap extendido
+            export NODE_OPTIONS="--max-old-space-size=1024"
             pnpm run build
             
+            # Eliminar devDependencies para liberar memoria en runtime
+            pnpm install --prod
+            
             # Iniciar o reiniciar la aplicación usando el ecosystem de pm2
-            pm2 startOrReload ecosystem.config.js --env production
+            pm2 startOrReload ecosystem.config.js --env production --node-args="--max-old-space-size=1024"
             
             # Guardar la lista actual de PM2 para que levante automático en caso de reinicio del server
             pm2 save


### PR DESCRIPTION
## Problem

The server runs out of memory during `pnpm build` and at runtime, causing 502 errors. The Node.js heap limit (default ~512MB) is insufficient for the project with 63+ source files and heavy dependencies.

## Fix

1. `export NODE_OPTIONS="--max-old-space-size=1024"` before `pnpm build` — doubles the heap for the build step
2. `pnpm install --prod` after build — removes devDependencies (vitest, RTL, jsdom) from node_modules to free runtime memory
3. `pm2 startOrReload --node-args="--max-old-space-size=1024"` — gives the runtime process 1GB heap

## Evidence

- v3.3.9 build log: `FATAL ERROR: JavaScript heap out of memory` at 472MB
- v3.3.10 build log: same OOM error at 472MB
- v3.3.5 works because fewer files, no test infrastructure